### PR TITLE
Bug Fix: redundant cropping on mouseup & Formatting

### DIFF
--- a/html/display.html
+++ b/html/display.html
@@ -1,4 +1,4 @@
-<div id="display" class="gr-block flex j-center">
+<div id="display" class="gr-block flex justify-center border border-gray-200 gr-padded mb-3">
 	<div>
 		<div id="crop_outer">
 			<div id="cropping_rect"></div>

--- a/javascript/sd_tagger.js
+++ b/javascript/sd_tagger.js
@@ -205,12 +205,17 @@ let onPageLoad = () => {
     let postImageLoad = setInterval(() => {
         ti = gradioApp().querySelector("#tagging_image img");
         if(ti) {
-            let display = gradioApp().querySelector("#display div");
-            display.appendChild(ti);
-            gradioApp().querySelector("#tagging_image").style.display = "none"; // Hide unused html. TODO Test if we can just remove this
+            let display_inner = gradioApp().querySelector("#display div");
+            let display = gradioApp().querySelector("#display");
+            let old_html = gradioApp().querySelector("#tagging_image");
+
+            old_html.style.position = "absolute";
+            old_html.style.top = "100%";
+
+            display_inner.appendChild(ti);
+            display.appendChild(old_html);
 
             // Format Tagging Image
-            ti.style.maxHeight = "500px";
             ti.classList.remove("w-full");
             ti.classList.add("h-full");
             ti.classList.add("tagging-img");

--- a/javascript/sd_tagger.js
+++ b/javascript/sd_tagger.js
@@ -47,12 +47,13 @@ let onPageLoad = () => {
 
         let mouseup = (e) => {
             if(e.button === 0) {
+                if(ti.pressed) {
+                    // Send for Crop
+                    cd.value = JSON.stringify(crop);
+                    cd.dispatchEvent(new CustomEvent("input", {}));
+                    cb.click();
+                }
                 cancel();
-
-                // Send for Crop
-                cd.value = JSON.stringify(crop);
-                cd.dispatchEvent(new CustomEvent("input", {}));
-                cb.click();
             }
             e.preventDefault();
         }
@@ -204,9 +205,9 @@ let onPageLoad = () => {
     let postImageLoad = setInterval(() => {
         ti = gradioApp().querySelector("#tagging_image img");
         if(ti) {
-
             let display = gradioApp().querySelector("#display div");
             display.appendChild(ti);
+            gradioApp().querySelector("#tagging_image").style.display = "none"; // Hide unused html. TODO Test if we can just remove this
 
             // Format Tagging Image
             ti.style.maxHeight = "500px";

--- a/style.css
+++ b/style.css
@@ -7,10 +7,6 @@
     display: none;
 }
 
-.j-center {
-    justify-content: center;
-}
-
 #cropping_rect {
     display: none;
     position: absolute;
@@ -25,6 +21,7 @@
 }
 
 .tagging-img {
+    max-height: 500px;
     -webkit-user-select: none;
     -webkit-user-drag: none;
 }


### PR DESCRIPTION
Cancelling the crop followed by mouseup would continue to crop.

Formatted the display image a bit. (padding, borders)